### PR TITLE
clean up GET params, 2nd approach

### DIFF
--- a/hubgrep/cli_blueprint/search.py
+++ b/hubgrep/cli_blueprint/search.py
@@ -4,7 +4,7 @@ from hubgrep import set_app_cache
 from hubgrep.lib.filter_results import filter_results
 from hubgrep.lib.fetch_results import fetch_concurrently
 from hubgrep.lib.get_hosting_service_interfaces import get_hosting_service_interfaces
-from hubgrep.frontend_blueprint.routes.index import SearchForm, _get_service_checkboxes
+from hubgrep.frontend_blueprint.routes.index import SearchForm, _get_exclude_service_checkboxes
 
 from hubgrep.cli_blueprint import cli_bp
 
@@ -24,7 +24,7 @@ def search(terms, no_forks, no_archived):
         print(error)
 
     form = SearchForm(search_phrase=" ".join(terms),
-                      service_checkboxes=_get_service_checkboxes(is_initial=True),
+                      service_checkboxes=_get_exclude_service_checkboxes(),
                       include_forks=include_fork,
                       include_archived=include_archived)
     results = filter_results(results, form)

--- a/hubgrep/frontend_blueprint/routes/index.py
+++ b/hubgrep/frontend_blueprint/routes/index.py
@@ -17,9 +17,9 @@ utc = pytz.UTC
 
 class SearchForm:
     search_phrase: str
-    service_checkboxes: [Checkbox]
-    include_forks: bool
-    include_archived: bool
+    exclude_service_checkboxes: [Checkbox]
+    exclude_forks: bool
+    exclude_archived: bool
     created_after: str
     created_before: str
     updated_after: str
@@ -28,9 +28,9 @@ class SearchForm:
     updated_after_dt: datetime
 
     def __init__(self, search_phrase: str,
-                 service_checkboxes: [Checkbox],
-                 include_forks: bool,
-                 include_archived: bool,
+                 exclude_service_checkboxes: [Checkbox],
+                 exclude_forks: bool,
+                 exclude_archived: bool,
                  created_after: str = "",
                  created_before: str = "",
                  updated_after: str = "",
@@ -38,9 +38,9 @@ class SearchForm:
                  created_before_dt: datetime = False,
                  updated_after_dt: datetime = False):
         self.search_phrase = search_phrase
-        self.service_checkboxes = service_checkboxes
-        self.include_forks = include_forks
-        self.include_archived = include_archived
+        self.exclude_service_checkboxes = exclude_service_checkboxes
+        self.exclude_forks = exclude_forks
+        self.exclude_archived = exclude_archived
         self.created_after = created_after
         self.created_before = created_before
         self.updated_after = updated_after
@@ -49,21 +49,21 @@ class SearchForm:
         self.updated_after_dt = updated_after_dt
 
 
-def _get_service_checkboxes(is_initial=True) -> {}:
-    service_checkboxes = dict()
+def _get_exclude_service_checkboxes() -> {}:
+    exclude_service_checkboxes = dict()
     for service in app.config["CACHED_HOSTING_SERVICES"]:
-        is_checked = is_initial or request.args.get("s{}".format(service.id), False) == "on"
-        service_checkboxes[service.id] = Checkbox(service_id=service.id, id="s{}".format(service.id),
+        is_checked = request.args.get("xs{}".format(service.id), False) == "on"
+        exclude_service_checkboxes[service.id] = Checkbox(service_id=service.id, id="xs{}".format(service.id),
                                                   label=service.label, is_checked=is_checked)
-    return service_checkboxes
+    return exclude_service_checkboxes
 
 
 def _get_search_form() -> SearchForm:
     # we default to "on" for missing checkbox params only when search_phrase is empty (as its the landing page)
     search_phrase = request.args.get("s", "")
-    include_forks = search_phrase == "" or request.args.get("f", False) == "on"
-    include_archived = search_phrase == "" or request.args.get("a", False) == "on"
-    service_checkboxes = _get_service_checkboxes(is_initial=search_phrase == "")
+    exclude_forks = request.args.get("f", False) == "on"
+    exclude_archived = request.args.get("a", False) == "on"
+    exclude_service_checkboxes = _get_exclude_service_checkboxes()
     created_after = request.args.get("ca", "")
     created_before = request.args.get("cb", "")
     updated_after = request.args.get("u", "")
@@ -77,8 +77,8 @@ def _get_search_form() -> SearchForm:
     if updated_after != "":
         updated_after_dt = utc.localize(datetime.strptime(updated_after, DATE_FORMAT))
 
-    return SearchForm(search_phrase=search_phrase, service_checkboxes=service_checkboxes,
-                      include_forks=include_forks, include_archived=include_archived,
+    return SearchForm(search_phrase=search_phrase, exclude_service_checkboxes=exclude_service_checkboxes,
+                      exclude_forks=exclude_forks, exclude_archived=exclude_archived,
                       created_after=created_after, created_after_dt=created_after_dt,
                       created_before=created_before, created_before_dt=created_before_dt,
                       updated_after=updated_after, updated_after_dt=updated_after_dt)

--- a/hubgrep/frontend_blueprint/templates/search/search_form.html
+++ b/hubgrep/frontend_blueprint/templates/search/search_form.html
@@ -28,18 +28,19 @@
         <div class="misc">
             <div class="misc-forks">
                 <input type="checkbox" id="forks" name="f"
-                       {% if form.include_forks %}checked{% endif %}>
-                <label for="forks">{{ gettext("include forks") | safe }}</label>
+                       {% if form.exclude_forks %}checked{% endif %}>
+                <label for="forks">{{ gettext("exclude forks") | safe }}</label>
             </div>
             <div class="misc-archived">
                 <input type="checkbox" id="archived" name="a"
-                       {% if form.include_archived %}checked{% endif %}>
-                <label for="archived">{{ gettext("include archived") | safe }}</label>
+                       {% if form.exclude_archived %}checked{% endif %}>
+                <label for="archived">{{ gettext("exclude archived") | safe }}</label>
             </div>
         </div>
 
         <div class="services">
-            {% for key, service in form.service_checkboxes.items() %}
+            exclude hoster:
+            {% for key, service in form.exclude_service_checkboxes.items() %}
                 <div class="hosting-service">
                     <input type="checkbox" id="{{ service.id }}" name="{{ service.id }}"
                            {% if service.is_checked %}checked{% endif %}>

--- a/hubgrep/lib/filter_results.py
+++ b/hubgrep/lib/filter_results.py
@@ -15,9 +15,11 @@ def _filter_by_date(item: SearchResult, form: "SearchForm") -> bool:
 def filter_results(results: [SearchResult], form: "SearchForm") -> [SearchResult]:
     def predicate(item: SearchResult):
         return (
-                (form.include_forks or not item.is_fork) and                        # filter forks
-                (form.include_archived or not item.is_archived) and                 # filter archived
-                form.service_checkboxes[item.host_service_id].is_checked and        # filter based on hosting-service
+                not (
+                    (form.exclude_forks and item.is_fork) or                        # filter forks
+                    (form.exclude_archived and item.is_archived)                    # filter archived
+                ) and
+                not form.exclude_service_checkboxes[item.host_service_id].is_checked and        # filter based on hosting-service
                 _filter_by_date(item, form)                                         # filters based on time
         )
 


### PR DESCRIPTION
sorry for rolling up an old topic again, but i woke up with a silly idea that i wanted to try out. :)

basically, this pr just inverts the search filters ("exclude service", "exclude forks"),which results in nicer urls.
also, it repairs simple requests like `http://localhost:8080/?s=asdf`, which wasnt working before on main, since it excluded all services.

...so, no POST this time, and also a minimal-invasive approach :)