### PR TITLE
start prod config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ htmlcov/
 *.egg-info/
 .env
 .webassets-cache/
-hubgrep/static/*.css
+hubgrep/static/css/
 messages.pot
 init_hosters.sh

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,23 @@
+FROM python:3.8-slim-buster
+
+# build variables
+ARG APP_ENV=build
+
+# build+run variables
+ENV FLASK_APP=hubgrep
+
+
+WORKDIR /var/task
+
+COPY requirements.txt Dockerfile.prod /var/task/
+COPY migrations /var/task/migrations
+COPY hubgrep /var/task/hubgrep
+
+RUN pip install -r requirements.txt
+
+# unicorn is used to serve the app
+RUN pip install gunicorn
+
+# we dont check css in, so we need to build our assets
+RUN flask assets build
+

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ docker-compose run --rm service /bin/bash
 flask cli search <TERMS>
 ```
 
-### Testing
+## Testing
 
 Using pytest and pytest-coverage, run:
 
@@ -110,5 +110,23 @@ Finally, compile the translation for usage:
     pybabel compile -d hubgrep/translations -l [YOUR_LANG]
     
 Strings should now be replaced by the appropriate locale variant when rendered.
+
+
+
+### building a production container
+
+there is a separate dockerfile `Dockerfile.prod` for production builds, 
+which is used in the `docker-compose.prod.yml` file.
+
+to build an image with generated assets and source code baked in, 
+run `docker-compose -f docker-compose.prod.yml build`.
+
+you can use it the same way as the development compose file.
+
+configuration is almost the same as in development - 
+just adjust your .env file, and change the docker-compose
+file to your needs (for example, if you are running a separate postgres.)
+
+    # todo: serve static assets via webserver, not gunicorn
 
 

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,3 +1,3 @@
 [python: **.py]
 [jinja2: **/templates/**.html]
-extensions=jinja2.ext.autoescape,jinja2.ext.with_
+extensions=jinja2.ext.autoescape,jinja2.ext.with_,webassets.ext.jinja2.AssetsExtension

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,29 @@
+version: "2"
+
+services:
+
+  postgres:
+    image: postgres:13
+    env_file: .env
+    environment:
+      POSTGRES_PASSWORD: ${HUBGREP_POSTGRES_PASSWORD}
+
+  redis:
+    image: redis
+
+  service:
+    build: 
+      context: .
+      dockerfile: Dockerfile.prod
+    env_file: .env
+
+    restart: ${RESTART}
+
+    # uplink port to host
+    ports:
+      - 8080:8080
+
+    command: gunicorn --bind 0.0.0.0:8080 "hubgrep:create_app()"
+
+volumes:
+  pgdata:

--- a/hubgrep/__init__.py
+++ b/hubgrep/__init__.py
@@ -37,6 +37,13 @@ WSGIRequestHandler.protocol_version = "HTTP/1.1"
 def create_app():
     app = Flask(__name__, static_url_path="/static", static_folder="static")
     assets = Environment(app)
+
+    # disable cache, because that breaks
+    # prod build for some reason.
+    # maybe add to the flask config?
+    assets.cache = False
+    assets.manifest = False
+
     _build_assets(assets)
 
     @app.after_request
@@ -47,6 +54,7 @@ def create_app():
 
     app_env = os.environ.get("APP_ENV", "development")
     config_mapping = {
+        "build": "hubgrep.config.BuildConfig",
         "development": "hubgrep.config.DevelopmentConfig",
         "production": "hubgrep.config.ProductionConfig",
         "testing": "hubgrep.config.testingConfig",
@@ -101,31 +109,31 @@ def _build_assets(assets: Environment):
         "scss/about.scss",
         filters="pyscss",
         depends=["**/*.scss", "**/**/*.scss"],
-        output="about.css",
+        output="css/about.css",
     )
     scss_imprint = Bundle(
         "scss/imprint.scss",
         filters="pyscss",
         depends=["**/*.scss", "**/**/*.scss"],
-        output="imprint.css",
+        output="css/imprint.css",
     )
     scss_search = Bundle(
         "scss/search.scss",
         filters="pyscss",
         depends=["**/*.scss", "**/**/*.scss"],
-        output="search.css",
+        output="css/search.css",
     )
     scss_search_empty = Bundle(
         "scss/search_empty.scss",
         filters="pyscss",
         depends=["**/*.scss", "**/**/*.scss"],
-        output="search_empty.css",
+        output="css/search_empty.css",
     )
     hosting_service_management = Bundle(
         "scss/hosting_service_management.scss",
         filters="pyscss",
         depends=["**/*.scss", "**/**/*.scss"],
-        output="hosting_service_management.css",
+        output="css/hosting_service_management.css",
     )
     assets.register("scss_about", scss_about)
     assets.register("scss_imprint", scss_imprint)

--- a/hubgrep/config/__init__.py
+++ b/hubgrep/config/__init__.py
@@ -2,28 +2,6 @@ import os
 
 
 class Config:
-    # user defined config
-    ENABLE_CACHE = os.environ.get("HUBGREP_ENABLE_CACHE", True)
-    CACHE_TIME = os.environ.get("HUBGREP_CACHE_TIME", 3600)
-    REDIS_URL = os.environ["HUBGREP_REDIS_URL"]
-
-    MAIL_DEBUG = os.environ.get('HUBGREP_MAIL_DEBUG', False)
-
-    MAIL_SERVER = os.environ['HUBGREP_MAIL_SERVER']
-    MAIL_PORT = os.environ['HUBGREP_MAIL_PORT']
-    MAIL_USE_TLS = os.environ.get('HUBGREP_MAIL_USE_TLS', False)
-    MAIL_USE_SSL = os.environ.get('HUBGREP_MAIL_USE_SSL', False)
-    MAIL_USERNAME = os.environ.get('HUBGREP_MAIL_USERNAME', False)
-    MAIL_PASSWORD = os.environ.get('HUBGREP_MAIL_PASSWORD', None)
-    MAIL_DEFAULT_SENDER = os.environ.get('HUBGREP_MAIL_DEFAULT_SENDER', None)
-    MAIL_MAX_EMAILS = os.environ.get('HUBGREP_MAIL_MAX_EMAILS', None)
-
-
-    SQLALCHEMY_DATABASE_URI = os.environ["HUBGREP_SQLALCHEMY_DATABASE_URI"]
-    SECURITY_PASSWORD_SALT = os.environ["HUBGREP_SECURITY_PASSWORD_SALT"]
-    SECRET_KEY = os.environ["HUBGREP_SECRET_KEY"]
-
-
     # hardcoded config
     DEBUG = False
     TESTING = False
@@ -63,15 +41,58 @@ class Config:
     PAGINATION_PER_PAGE_DEFAULT = 10
 
 
-class ProductionConfig(Config):
-    pass
+class _EnvironmentConfig():
+    # user defined config
+    ENABLE_CACHE = os.environ.get("HUBGREP_ENABLE_CACHE", True)
+    CACHE_TIME = os.environ.get("HUBGREP_CACHE_TIME", 3600)
+    REDIS_URL = os.environ.get("HUBGREP_REDIS_URL", False)
+
+    MAIL_DEBUG = os.environ.get('HUBGREP_MAIL_DEBUG', False)
+
+    MAIL_SERVER = os.environ.get('HUBGREP_MAIL_SERVER', False)
+    MAIL_PORT = os.environ.get('HUBGREP_MAIL_PORT', False)
+    MAIL_USE_TLS = os.environ.get('HUBGREP_MAIL_USE_TLS', False)
+    MAIL_USE_SSL = os.environ.get('HUBGREP_MAIL_USE_SSL', False)
+    MAIL_USERNAME = os.environ.get('HUBGREP_MAIL_USERNAME', False)
+    MAIL_PASSWORD = os.environ.get('HUBGREP_MAIL_PASSWORD', None)
+    MAIL_DEFAULT_SENDER = os.environ.get('HUBGREP_MAIL_DEFAULT_SENDER', None)
+    MAIL_MAX_EMAILS = os.environ.get('HUBGREP_MAIL_MAX_EMAILS', None)
 
 
-class DevelopmentConfig(Config):
+    SQLALCHEMY_DATABASE_URI = os.environ.get("HUBGREP_SQLALCHEMY_DATABASE_URI", False)
+    SECURITY_PASSWORD_SALT = os.environ.get("HUBGREP_SECURITY_PASSWORD_SALT", False)
+    SECRET_KEY = os.environ.get("HUBGREP_SECRET_KEY", False)
+
+class ProductionConfig(Config, _EnvironmentConfig):
+    DEBUG = False
+
+class DevelopmentConfig(Config, _EnvironmentConfig):
     DEBUG = True
 
+class BuildConfig(Config):
+    TESTING = True
+    DEBUG = True
+    SECURITY_SEND_REGISTER_EMAIL = False
+
+    ENABLE_CACHE = False
+    CACHE_TIME = 3600
+
+    MAIL_DEBUG = False
+
+    SQLALCHEMY_DATABASE_URI = ""
+    SECURITY_PASSWORD_SALT = ""
+    SECRET_KEY = ""
 
 class TestingConfig(Config):
     TESTING = True
     DEBUG = True
     SECURITY_SEND_REGISTER_EMAIL = False
+
+    ENABLE_CACHE = False
+    CACHE_TIME = 3600
+
+    MAIL_DEBUG = False
+
+    SQLALCHEMY_DATABASE_URI = ""
+    SECURITY_PASSWORD_SALT = ""
+    SECRET_KEY = ""

--- a/hubgrep/static/scss/search_empty.scss
+++ b/hubgrep/static/scss/search_empty.scss
@@ -28,7 +28,7 @@ body > section {
         width: 250px;
         height: 161px;
         background-size: cover;
-        background: url('images/frog_big.png') no-repeat center;
+        background: url('../images/frog_big.png') no-repeat center;
       }
 
       .eye {
@@ -40,7 +40,7 @@ body > section {
         width: 43px;
         height: 41px;
         background-size: cover;
-        background: url('images/frog_big_eye.png') no-repeat center;
+        background: url('../images/frog_big_eye.png') no-repeat center;
         background-color: color(frogEye);
       }
 


### PR DESCRIPTION
this pr is the beginning a config for production builds.
made a separate dockerfile.prod which adds the sources instead of linking the local filesystem to the container, and builds our assets.

also, separate compose file which uses gunicorn instead of the built-in server.
restructured the config a bit, because the asset building broke without the envvars.

we still need something to get the assets out of the container somehow, to serve them with a real webserver. 
maybe a cli command, but thats not part of this pr.
