### PR TITLE
refactor various return dicts into classes

### DIFF
--- a/hubgrep/frontend_blueprint/routes/search.py
+++ b/hubgrep/frontend_blueprint/routes/search.py
@@ -27,14 +27,14 @@ def search():
                       created_before=request.args.get("cb", ""),
                       updated_after=request.args.get("ua", ""))
     search_feedback = ""
-    failed_responses = []
+    failed_requests = []
     pagination_links = []
     if form.search_phrase:
         terms = form.search_phrase.split()
         search_interfaces = get_hosting_service_interfaces()
         aggregated_result = fetch_concurrently(terms, search_interfaces)
         results = filter_results(aggregated_result.search_results, form)
-        failed_responses = aggregated_result.failed_responses
+        failed_requests = aggregated_result.failed_requests
         results_paginated = results[results_offset:(results_offset + results_per_page)]
         pagination_links = get_page_links(request.full_path, results_offset, results_per_page, len(results))
         search_feedback = get_search_feedback(len(results))
@@ -45,7 +45,7 @@ def search():
                            search_results=results_paginated,
                            search_feedback=search_feedback,
                            pagination_links=pagination_links,  # [PageLink] namedtuples
-                           failed_responses=failed_responses)  # TODO these errors should be formatted to text that is useful for a enduser
+                           failed_requests=failed_requests)  # TODO these errors should be formatted to text that is useful for a enduser
 
 
 def get_search_feedback(results_total: int) -> str:

--- a/hubgrep/frontend_blueprint/routes/search.py
+++ b/hubgrep/frontend_blueprint/routes/search.py
@@ -27,13 +27,14 @@ def search():
                       created_before=request.args.get("cb", ""),
                       updated_after=request.args.get("ua", ""))
     search_feedback = ""
-    external_errors = []
+    failed_responses = []
     pagination_links = []
     if form.search_phrase:
         terms = form.search_phrase.split()
         search_interfaces = get_hosting_service_interfaces()
-        results, external_errors = fetch_concurrently(terms, search_interfaces)
-        results = filter_results(results, form)
+        aggregated_result = fetch_concurrently(terms, search_interfaces)
+        results = filter_results(aggregated_result.search_results, form)
+        failed_responses = aggregated_result.failed_responses
         results_paginated = results[results_offset:(results_offset + results_per_page)]
         pagination_links = get_page_links(request.full_path, results_offset, results_per_page, len(results))
         search_feedback = get_search_feedback(len(results))
@@ -44,7 +45,7 @@ def search():
                            search_results=results_paginated,
                            search_feedback=search_feedback,
                            pagination_links=pagination_links,  # [PageLink] namedtuples
-                           external_errors=external_errors)  # TODO these errors should be formatted to text that is useful for a enduser
+                           failed_responses=failed_responses)  # TODO these errors should be formatted to text that is useful for a enduser
 
 
 def get_search_feedback(results_total: int) -> str:

--- a/hubgrep/frontend_blueprint/templates/search/search_base.html
+++ b/hubgrep/frontend_blueprint/templates/search/search_base.html
@@ -16,7 +16,7 @@
         <div class="search-result">
             <div class="search-result-messages">
                 {% import "components/status_message/status_message.html" as status %}
-                {% for failure in failed_responses %}
+                {% for failure in failed_requests %}
                     {{ status.message("warn", failure.hosting_service_interface.label ~ ": " ~ failure.response.error_msg , "TODO FORMAT ERROR TEXTS FOR ENDUSER: ") }}
                 {% endfor %}
                 {{ status.message("info", search_feedback) }}

--- a/hubgrep/frontend_blueprint/templates/search/search_base.html
+++ b/hubgrep/frontend_blueprint/templates/search/search_base.html
@@ -16,8 +16,8 @@
         <div class="search-result">
             <div class="search-result-messages">
                 {% import "components/status_message/status_message.html" as status %}
-                {% for hosting_service_interface, cached_response in external_errors %}
-                    {{ status.message("warn", hosting_service_interface.label ~ ": " ~ cached_response.error_msg , "TODO FORMAT ERROR TEXTS FOR ENDUSER: ") }}
+                {% for failure in failed_responses %}
+                    {{ status.message("warn", failure.hosting_service_interface.label ~ ": " ~ failure.response.error_msg , "TODO FORMAT ERROR TEXTS FOR ENDUSER: ") }}
                 {% endfor %}
                 {{ status.message("info", search_feedback) }}
             </div>

--- a/hubgrep/lib/cached_session/cached_session.py
+++ b/hubgrep/lib/cached_session/cached_session.py
@@ -58,7 +58,7 @@ class CachedSession:
             response_result = CachedResponse.from_serialized(response_result_str)
             return response_result
 
-    def get(self, url, *args, **kwargs):
+    def get(self, url, *args, **kwargs) -> CachedResponse:
         return self.request('get', url, *args, **kwargs)
 
     @property

--- a/hubgrep/lib/fetch_results.py
+++ b/hubgrep/lib/fetch_results.py
@@ -81,7 +81,9 @@ def fetch_concurrently(
                         _normalize(interface_result.search_results)
                         results += interface_result.search_results
                 else:
-                    failed_responses.append(FailedSearchResult(hosting_service_interface, interface_result.response))
+                    failed_responses.append(
+                        FailedSearchResult(interface_result.hosting_service_interface, interface_result.response)
+                    )
         except futures._base.TimeoutError as e:
             logger.error("something went wrong with the requests")
             logger.error(e, exc_info=True)

--- a/hubgrep/lib/fetch_results.py
+++ b/hubgrep/lib/fetch_results.py
@@ -102,8 +102,8 @@ class FailedSearchResult:
 
 class AggregatedSearchResults:
     search_results: List[SearchResult]
-    failed_responses: List[FailedSearchResult]
+    failed_requests: List[FailedSearchResult]
 
-    def __init__(self, search_results: List[SearchResult], failed_responses: List[FailedSearchResult]):
+    def __init__(self, search_results: List[SearchResult], failed_requests: List[FailedSearchResult]):
         self.search_results = search_results
-        self.failed_responses = failed_responses
+        self.failed_requests = failed_requests

--- a/hubgrep/lib/fetch_results.py
+++ b/hubgrep/lib/fetch_results.py
@@ -52,7 +52,7 @@ def _normalize(results):
 
 
 def fetch_concurrently(
-        keywords, hosting_service_interfaces: List[HostingServiceInterface]
+    keywords, hosting_service_interfaces: List[HostingServiceInterface]
 ) -> "AggregatedSearchResults":
     # maybe as much executors as interfaces?
     with futures.ThreadPoolExecutor(max_workers=20) as executor:

--- a/hubgrep/lib/hosting_service_interfaces/_hosting_service_interface.py
+++ b/hubgrep/lib/hosting_service_interfaces/_hosting_service_interface.py
@@ -7,12 +7,11 @@ import requests
 import pytz
 
 from urllib.parse import urljoin
-from typing import Union, List
+from typing import List
 
 from flask import current_app
 from hubgrep.lib.cached_session.cached_session import CachedSession
 from hubgrep.lib.cached_session.cached_response import CachedResponse
-
 
 logger = logging.getLogger(__name__)
 
@@ -21,20 +20,20 @@ utc = pytz.UTC
 
 class SearchResult:
     def __init__(
-        self,
-        host_service_id,
-        repo_name,
-        repo_description,
-        html_url,
-        owner_name,
-        last_commit_dt,
-        created_at_dt,
-        forks,
-        stars,
-        is_fork,
-        is_archived,
-        language=None,
-        license=None,
+            self,
+            host_service_id,
+            repo_name,
+            repo_description,
+            html_url,
+            owner_name,
+            last_commit_dt,
+            created_at_dt,
+            forks,
+            stars,
+            is_fork,
+            is_archived,
+            language=None,
+            license=None,
     ):
         self.host_service_id = host_service_id
         self.repo_name = repo_name
@@ -85,35 +84,39 @@ class HostingServiceInterface:
     name = ""
 
     def __init__(
-        self,
-        host_service_id,
-        api_url,
-        label,
-        search_path,
-        cached_session: CachedSession,
-        timeout=None,
+            self,
+            host_service_id,
+            api_url,
+            search_path,
+            label,
+            config_dict,
+            cached_session: CachedSession,
+            timeout=None,
     ):
-
         self.host_service_id = host_service_id
         self.api_url = api_url
         self.label = label
+        self.config_dict = config_dict
         self.request_url = urljoin(self.api_url, search_path)
         self.timeout = timeout
         self.cached_session = cached_session
         self.cached_session.headers.update({"referer": current_app.config["REFERER"]})
 
     def search(
-        self, keywords: list = [], tags: dict = {}
-    ) -> ("HostingServiceInterface", CachedResponse, List):
+            self, keywords: list = [], tags: dict = {}
+    ) -> "HostingServiceInterfaceResult":
         time_before = time.time()
-        hosting_service_interface, response_result, results = self._search(
+        hosting_service_interface_result = self._search(
             keywords, tags
         )
         logger.debug(f"search on {self.api_url} took {time.time() - time_before}s")
-        return hosting_service_interface, response_result, results
+        return hosting_service_interface_result
 
-    def _search(self, keywords: list, tags: dict):
+    def _search(self, keywords: list, tags: dict) -> "HostingServiceInterfaceResult":
         raise NotImplementedError
+
+    def _get_request_headers(self) -> dict:
+        return dict()
 
     @staticmethod
     def default_api_url_from_landingpage_url(landingpage_url: str) -> str:
@@ -123,3 +126,17 @@ class HostingServiceInterface:
     def normalize_url(url):
         response = requests.head(url)
         return response.url
+
+
+class HostingServiceInterfaceResult:
+    hosting_service_interface: HostingServiceInterface
+    response: CachedResponse
+    search_results: List[SearchResult]
+
+    def __init__(self,
+                 hosting_service_interface: HostingServiceInterface,
+                 response: CachedResponse,
+                 search_results: List[SearchResult]):
+        self.hosting_service = hosting_service_interface
+        self.response = response
+        self.search_results = search_results

--- a/hubgrep/lib/hosting_service_interfaces/_hosting_service_interface.py
+++ b/hubgrep/lib/hosting_service_interfaces/_hosting_service_interface.py
@@ -20,20 +20,20 @@ utc = pytz.UTC
 
 class SearchResult:
     def __init__(
-            self,
-            host_service_id,
-            repo_name,
-            repo_description,
-            html_url,
-            owner_name,
-            last_commit_dt,
-            created_at_dt,
-            forks,
-            stars,
-            is_fork,
-            is_archived,
-            language=None,
-            license=None,
+        self,
+        host_service_id,
+        repo_name,
+        repo_description,
+        html_url,
+        owner_name,
+        last_commit_dt,
+        created_at_dt,
+        forks,
+        stars,
+        is_fork,
+        is_archived,
+        language=None,
+        license=None,
     ):
         self.host_service_id = host_service_id
         self.repo_name = repo_name
@@ -84,14 +84,14 @@ class HostingServiceInterface:
     name = ""
 
     def __init__(
-            self,
-            host_service_id,
-            api_url,
-            search_path,
-            label,
-            config_dict,
-            cached_session: CachedSession,
-            timeout=None,
+        self,
+        host_service_id,
+        api_url,
+        search_path,
+        label,
+        config_dict,
+        cached_session: CachedSession,
+        timeout=None,
     ):
         self.host_service_id = host_service_id
         self.api_url = api_url

--- a/hubgrep/lib/hosting_service_interfaces/gitlab.py
+++ b/hubgrep/lib/hosting_service_interfaces/gitlab.py
@@ -70,13 +70,13 @@ class GitLabSearch(HostingServiceInterface):
     name = "GitLab"
 
     def __init__(
-            self,
-            host_service_id,
-            api_url,
-            label,
-            config_dict,
-            cached_session,
-            timeout=None,
+        self,
+        host_service_id,
+        api_url,
+        label,
+        config_dict,
+        cached_session,
+        timeout=None,
     ):
         super().__init__(
             host_service_id=host_service_id,

--- a/hubgrep/lib/hosting_service_interfaces/gitlab.py
+++ b/hubgrep/lib/hosting_service_interfaces/gitlab.py
@@ -2,11 +2,9 @@ import logging
 from iso8601 import iso8601
 from urllib.parse import urljoin
 
-from typing import List, Union
-
-from hubgrep.lib.cached_session.cached_response import CachedResponse
 from hubgrep.lib.hosting_service_interfaces._hosting_service_interface import (
     HostingServiceInterface,
+    HostingServiceInterfaceResult,
     SearchResult,
 )
 
@@ -72,45 +70,53 @@ class GitLabSearch(HostingServiceInterface):
     name = "GitLab"
 
     def __init__(
-        self,
-        host_service_id,
-        api_url,
-        label,
-        config_dict,
-        cached_session,
-        timeout=None,
+            self,
+            host_service_id,
+            api_url,
+            label,
+            config_dict,
+            cached_session,
+            timeout=None,
     ):
         super().__init__(
             host_service_id=host_service_id,
             api_url=api_url,
             label=label,
+            config_dict=config_dict,
             search_path="search",
             cached_session=cached_session,
             timeout=timeout,
         )
-        self.api_token = config_dict["api_token"]
 
     def _search(
-        self, keywords: list = [], tags: dict = {}
-    ) -> ("GitLabSearch", CachedResponse, List[GitLabSearchResult]):
+            self, keywords: list = [], tags: dict = {}
+    ) -> HostingServiceInterfaceResult:
         tags = {**tags, **dict(scope="projects")}
         params = dict(search="+".join(keywords), **tags)
 
-        response_result = self.cached_session.get(
+        response = self.cached_session.get(
             self.request_url,
             params=params,
-            headers={"PRIVATE-TOKEN": self.api_token},
+            headers=self._get_request_headers(),
             timeout=self.timeout,
         )
-        if response_result.success:
+        if response.success:
             results = [
                 GitLabSearchResult(item, self.host_service_id)
-                for item in response_result.response_json
+                for item in response.response_json
             ]
         else:
             results = []
-        return self, response_result, results
+        return HostingServiceInterfaceResult(self, response, results)
 
     @staticmethod
     def default_api_url_from_landingpage_url(landingpage_url: str) -> str:
         return urljoin(landingpage_url, "/api/v4/")
+
+    def _get_request_headers(self):
+        headers = super()._get_request_headers()
+        if "api_token" in self.config_dict:
+            headers["PRIVATE-TOKEN"] = self.config_dict["api_token"]
+        else:
+            logger.warning(
+                f"setting GITLAB headers without PRIVATE-TOKEN - Config: {self.config_dict} - Headers: {headers}")

--- a/tests/lib/hosting_service_interfaces/test__hosting_service_interface.py
+++ b/tests/lib/hosting_service_interfaces/test__hosting_service_interface.py
@@ -13,6 +13,8 @@ class TestHostingServiceInterface:
                 "host_service_id",
                 "base_url",
                 "search_path",
+                "a label",
+                dict(),
                 cached_session=cached_session,
                 timeout=2,
             )

--- a/tests/lib/hosting_service_interfaces/test_get_hosting_services.py
+++ b/tests/lib/hosting_service_interfaces/test_get_hosting_services.py
@@ -1,12 +1,11 @@
 import pytest
-from hubgrep.lib.get_hosting_service_interfaces import (
+from hubgrep.lib.hosting_service_interfaces.get_hosting_service_interfaces import (
     get_hosting_service_interfaces,
     _get_cache_backend,
     UnknownBackendException,
 )
 
 from hubgrep.lib.cached_session.caches.no_cache import NoCache
-from hubgrep.lib.cached_session.caches.redis_cache import RedisCache
 
 
 class TestGetHostingServices:

--- a/tests/lib/hosting_service_interfaces/test_gitea.py
+++ b/tests/lib/hosting_service_interfaces/test_gitea.py
@@ -1,8 +1,10 @@
 from unittest.mock import Mock
 
+from hubgrep.lib.hosting_service_interfaces._hosting_service_interface import HostingServiceInterfaceResult
 from hubgrep.lib.hosting_service_interfaces.gitea import GiteaSearch, GiteaSearchResult
 
 from hubgrep.lib.cached_session.cached_response import CachedResponse
+
 
 class TestGitea:
     def get_cached_response(self):
@@ -36,19 +38,19 @@ class TestGitea:
     def test_search(self, test_app, cached_session):
         with test_app.app_context():
             gitea_search = GiteaSearch(
-                "host_service_id", "api_url", cached_session=cached_session, timeout=2
+                "host_service_id", "api_url", "a label", dict(), cached_session=cached_session, timeout=2
             )
             gitea_search.cached_session.get = Mock()
             gitea_search.cached_session.get.return_value = self.get_cached_response()
 
-            cached_response, results = gitea_search.search("")
+            interface_result = gitea_search.search("")
 
-            if not cached_response.success:
-                raise cached_response.error_msg
+            if not interface_result.response.success:
+                raise Exception(interface_result.response.error_msg)
 
-            result: GiteaSearchResult = results[0]
+            result = interface_result.search_results[0]
 
-            assert cached_response.success is True
-            assert cached_response.url == "api_url"
+            assert interface_result.response.success is True
+            assert interface_result.response.url == "api_url"
             assert result.repo_name == "name"
             assert result.created_at_dt.timestamp() == 0

--- a/tests/lib/hosting_service_interfaces/test_github.py
+++ b/tests/lib/hosting_service_interfaces/test_github.py
@@ -45,20 +45,22 @@ class TestGithub:
             github_search = GitHubSearch(
                 "host_service_id",
                 "api_url",
+                "a label",
+                dict(),
                 cached_session=cached_session,
                 timeout=2
             )
             github_search.cached_session = Mock()
             github_search.cached_session.get.return_value = self.get_cached_response()
 
-            cached_response, results = github_search.search("")
+            interface_result = github_search.search("")
 
-            if not cached_response.success:
-                raise cached_response.error_msg
+            if not interface_result.response.success:
+                raise Exception(interface_result.response.error_msg)
 
-            result: GitHubSearchResult = results[0]
+            result = interface_result.search_results[0]
 
-            assert cached_response.success is True
-            assert cached_response.url == "api_url"
+            assert interface_result.response.success is True
+            assert interface_result.response.url == "api_url"
             assert result.repo_name == "name"
             assert result.created_at_dt.timestamp() == 0

--- a/tests/lib/hosting_service_interfaces/test_gitlab.py
+++ b/tests/lib/hosting_service_interfaces/test_gitlab.py
@@ -39,21 +39,22 @@ class TestGitlab:
             gitlab_search = GitLabSearch(
                 "host_service_id",
                 "api_url",
-                "api_token",
+                "a label",
+                dict(),
                 cached_session=cached_session,
                 timeout=2,
             )
             gitlab_search.cached_session = Mock()
             gitlab_search.cached_session.get.return_value = self.get_cached_response()
 
-            cached_response, results = gitlab_search.search("")
+            interface_result = gitlab_search.search("")
 
-            if not cached_response.success:
-                raise cached_response.error_msg
+            if not interface_result.response.success:
+                raise Exception(interface_result.response.error_msg)
 
-            result: GitLabSearchResult = results[0]
+            result = interface_result.search_results[0]
 
-            assert cached_response.success is True
-            assert cached_response.url == "api_url"
+            assert interface_result.response.success is True
+            assert interface_result.response.url == "api_url"
             assert result.repo_name == "name"
             assert result.created_at_dt.timestamp() == 0


### PR DESCRIPTION
I checked your PR, and I think your refactoring is the right direction. 

Now, in this PR I only extend what you were already doing, by making return dicts into classes. These will be easier to extend without breaking stuff and it improves type-hinting, and a lot of changes are just making sure that consumers use the new classes by property access instead of unpacking a dict.

Also fixed tests for this.