### PR TITLE
Feature/module docstrings

### DIFF
--- a/hubgrep/__init__.py
+++ b/hubgrep/__init__.py
@@ -1,3 +1,6 @@
+"""
+HubGrep Flask-app initialization script
+"""
 import logging
 import os
 from flask import Flask, request
@@ -32,6 +35,7 @@ WSGIRequestHandler.protocol_version = "HTTP/1.1"
 
 
 def create_app():
+    """ Create a HubGrep Flask-app. """
     app = Flask(__name__, static_url_path="/static", static_folder="static")
     assets = Environment(app)
 
@@ -99,7 +103,7 @@ def create_app():
 
 
 def set_app_cache():
-    # used to avoid calling the db on every request for common almost-static models
+    """ Set common cache properties for the app, used to avoid calling the db for almost-static models. """
     from flask import current_app as app
     from hubgrep.models import HostingService
     app.config["CACHED_HOSTING_SERVICES"] = HostingService.query.all()

--- a/hubgrep/config/__init__.py
+++ b/hubgrep/config/__init__.py
@@ -1,8 +1,12 @@
+"""
+HubGrep environment configurations.
+"""
 import os
 from hubgrep.constants import HOSTING_SERVICE_REQUEST_TIMEOUT_DEFAULT
 
 
 class Config:
+    """ Base configuration. """
     # hardcoded config
     DEBUG = False
     TESTING = False
@@ -88,15 +92,18 @@ class _EnvironmentConfig:
 
 
 class ProductionConfig(Config, _EnvironmentConfig):
+    """ Production Configuration. """
     DEBUG = False
 
 
 class DevelopmentConfig(Config, _EnvironmentConfig):
+    """ Development configuration. """
     DEBUG = True
     WATCH_SCSS = True
 
 
 class BuildConfig(Config):
+    """ Build configuration, in bundling and preparation for deployment. """
     TESTING = True
     DEBUG = True
     SECURITY_SEND_REGISTER_EMAIL = False
@@ -113,6 +120,7 @@ class BuildConfig(Config):
 
 
 class TestingConfig(Config):
+    """ Test configuration, as used by tests. """
     TESTING = True
     DEBUG = True
     SECURITY_SEND_REGISTER_EMAIL = False

--- a/hubgrep/constants.py
+++ b/hubgrep/constants.py
@@ -1,3 +1,4 @@
+""" HubGrep constants """
 
 # app
 APP_ENV_BUILD = "build"

--- a/hubgrep/frontend_blueprint/forms/__init__.py
+++ b/hubgrep/frontend_blueprint/forms/__init__.py
@@ -1,0 +1,1 @@
+""" Form logic and validation for use in templates. """

--- a/hubgrep/frontend_blueprint/forms/confirm.py
+++ b/hubgrep/frontend_blueprint/forms/confirm.py
@@ -1,3 +1,5 @@
+""" Generic confirm form intended for use by other forms. """
+
 import logging
 from flask_wtf import FlaskForm
 

--- a/hubgrep/frontend_blueprint/forms/edit_hosting_service.py
+++ b/hubgrep/frontend_blueprint/forms/edit_hosting_service.py
@@ -1,9 +1,11 @@
+""" Form value-object classes and validation functions for editing hosting services. """
+
 import json
 import logging
 from flask_wtf import FlaskForm
-from wtforms import StringField, SelectField, TextField, TextAreaField
+from wtforms import StringField, SelectField, TextAreaField
 from wtforms.widgets.html5 import URLInput
-from wtforms.validators import DataRequired, ValidationError, URL
+from wtforms.validators import ValidationError, URL
 from wtforms.validators import InputRequired
 
 from hubgrep.lib.get_hosting_service_interfaces import hosting_service_interfaces_by_name
@@ -13,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def validate_config(form, field):
+    """ Validate the config field to adhere to JSON syntax. """
     if not field.data:
         field.data = "{}"
     try:
@@ -28,6 +31,7 @@ def validate_config(form, field):
             )
 
 def validate_url(form, field):
+    """ Validate URLs. """
     HostingServiceInterface = hosting_service_interfaces_by_name.get(form.type.data, False)
     if not HostingServiceInterface:
         raise ValidationError("invalid hosting service interface!")
@@ -35,10 +39,7 @@ def validate_url(form, field):
 
 
 class HostingServiceFirstStep(FlaskForm):
-    """
-    only get type and landingpage from user,
-    we want to figure out the rest to prefill step 2
-    """
+    """ Only get type and landingpage from the user, the rest we automatically resolve to pre-fill in step 2. """
     type = SelectField(
         u"Type",
         [InputRequired()],
@@ -59,10 +60,7 @@ class HostingServiceFirstStep(FlaskForm):
     )
 
 class HostingServiceForm(HostingServiceFirstStep):
-    """
-    final step in adding new hosters,
-    also form for editing hosters
-    """
+    """ Final step when adding a new hosting-service, doubling as the form used for editing hosting-services. """
     api_url = StringField("Api Url", [InputRequired(), URL(), validate_url], widget=URLInput())
     config = TextAreaField("Config", [validate_config])
 

--- a/hubgrep/frontend_blueprint/routes/__init__.py
+++ b/hubgrep/frontend_blueprint/routes/__init__.py
@@ -1,0 +1,1 @@
+""" HubGrep routes """

--- a/hubgrep/frontend_blueprint/routes/about.py
+++ b/hubgrep/frontend_blueprint/routes/about.py
@@ -1,3 +1,5 @@
+""" About page route. """
+
 import markdown
 from flask import render_template
 from flask import current_app as app

--- a/hubgrep/frontend_blueprint/routes/add_instance.py
+++ b/hubgrep/frontend_blueprint/routes/add_instance.py
@@ -1,3 +1,5 @@
+""" Add instance page routes. """
+
 from flask import render_template
 from flask import request
 from flask import abort

--- a/hubgrep/frontend_blueprint/routes/hoster_list.py
+++ b/hubgrep/frontend_blueprint/routes/hoster_list.py
@@ -1,3 +1,5 @@
+""" Hosters list page route. """
+
 from flask import render_template, current_app as app
 from hubgrep.frontend_blueprint import frontend
 

--- a/hubgrep/frontend_blueprint/routes/manage.py
+++ b/hubgrep/frontend_blueprint/routes/manage.py
@@ -1,3 +1,5 @@
+""" Manage page route. """
+
 from flask import render_template
 from flask import abort
 from flask import flash

--- a/hubgrep/frontend_blueprint/routes/search.py
+++ b/hubgrep/frontend_blueprint/routes/search.py
@@ -1,3 +1,5 @@
+""" Search page route. """
+
 from flask import render_template
 from flask import current_app as app
 from flask import request

--- a/hubgrep/lib/__init__.py
+++ b/hubgrep/lib/__init__.py
@@ -1,0 +1,3 @@
+"""
+HubGrep library functions and classes.
+"""

--- a/hubgrep/lib/cached_session/__init__.py
+++ b/hubgrep/lib/cached_session/__init__.py
@@ -1,0 +1,4 @@
+"""
+HubGrep request cache is modular, so we need to implement interfaces for each cache vendor that we want to allow.
+The output is wrapped by CachedResponse for normalization, and a CachedSession is responsible for resolving requests.
+"""

--- a/hubgrep/lib/cached_session/caches/__init__.py
+++ b/hubgrep/lib/cached_session/caches/__init__.py
@@ -1,0 +1,3 @@
+"""
+Cache interfaces for retrieving data from specific cache vendors, such as Redis.
+"""

--- a/hubgrep/lib/cached_session/caches/no_cache.py
+++ b/hubgrep/lib/cached_session/caches/no_cache.py
@@ -1,8 +1,6 @@
 
 class NoCache:
-    """
-    dummy cache for CachedSession, doing nothing
-    """
+    """ Dummy cache for CachedSession, doing nothing. """
     def __init__(self):
         pass
 

--- a/hubgrep/lib/cached_session/caches/redis_cache.py
+++ b/hubgrep/lib/cached_session/caches/redis_cache.py
@@ -4,9 +4,7 @@ import redis
 
 
 class RedisCache:
-    """
-    redis cache for CachedSession
-    """
+    """ Redis cache for CachedSession. """
     def __init__(self, redis_url, expire_after):
         self.cache_time = expire_after
         self.redis_client = redis.from_url(redis_url)

--- a/hubgrep/lib/create_admin.py
+++ b/hubgrep/lib/create_admin.py
@@ -4,6 +4,7 @@ from flask_security import hash_password
 from hubgrep import db
 
 def create_admin(admin_email, admin_password):
+    """ Create a database admin user with username (from email) and password. """
     admin = security.datastore.find_user(email=admin_email)
     if not admin:
         admin = security.datastore.create_user(

--- a/hubgrep/lib/fetch_results.py
+++ b/hubgrep/lib/fetch_results.py
@@ -1,3 +1,7 @@
+"""
+Retrieve and aggregate repository results.
+"""
+
 import logging
 import difflib
 from concurrent import futures
@@ -15,9 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def final_sort(keywords, results):
-    """
-    order results based on normalized score and best text match
-    """
+    """ Order results based on normalized score and best text match. """
     # https://stackoverflow.com/questions/17903706/how-to-sort-list-of-strings-by-best-match-difflib-ratio
     def _key(result: SearchResult):
         key = result.repo_name + " " + result.repo_description
@@ -31,7 +33,7 @@ def final_sort(keywords, results):
 
 def _normalize(results):
     """
-    normalize fork count of the results of a service
+    Normalize fork count of the results of a service.
 
     # todo: last commit, age, stars...?
     # what about a "group" of forks?
@@ -51,6 +53,7 @@ def _normalize(results):
 def fetch_concurrently(
     keywords, hosting_service_interfaces: List[HostingServiceInterface]
 ):
+    """ Asynchronously retrieve and aggregate results from external hosting-services. """
     # maybe as much executors as interfaces?
     with futures.ThreadPoolExecutor(max_workers=20) as executor:
         to_do = []

--- a/hubgrep/lib/filter_results.py
+++ b/hubgrep/lib/filter_results.py
@@ -1,3 +1,5 @@
+""" Filter search results. """
+
 from typing import TYPE_CHECKING
 from hubgrep.lib.hosting_service_interfaces._hosting_service_interface import SearchResult
 
@@ -6,6 +8,7 @@ if TYPE_CHECKING:
 
 
 def _filter_by_date(item: SearchResult, form: "SearchForm") -> bool:
+    """ Filter results based on time against cutoffs defined in hubgrep.lib.search_form. """
     return (
             (not form.created_after_dt or item.created_at_dt > form.created_after_dt) and
             (not form.created_before_dt or item.created_at_dt < form.created_before_dt) and
@@ -14,6 +17,7 @@ def _filter_by_date(item: SearchResult, form: "SearchForm") -> bool:
 
 
 def filter_results(results: [SearchResult], form: "SearchForm") -> [SearchResult]:
+    """ Filter results by properties defined in hubgrep.lib.search_form. """
     def predicate(item: SearchResult):
         return (
                 not (

--- a/hubgrep/lib/hosting_service_interfaces/__init__.py
+++ b/hubgrep/lib/hosting_service_interfaces/__init__.py
@@ -1,2 +1,4 @@
-
+"""
+HubGrep retrieves results from external hosting-services (such as GitHub, or GitLab). This is done via these interfaces.
+"""
 

--- a/hubgrep/lib/hosting_service_interfaces/_hosting_service_interface.py
+++ b/hubgrep/lib/hosting_service_interfaces/_hosting_service_interface.py
@@ -1,3 +1,7 @@
+"""
+Base-classes for search results and hosting-service interfaces.
+"""
+
 import logging
 import time
 
@@ -19,6 +23,7 @@ utc = pytz.UTC
 
 
 class SearchResult:
+    """ A single repository result as retrieved by all hosting-service interfaces """
     def __init__(
             self,
             host_service_id,
@@ -81,6 +86,7 @@ class SearchResult:
 
 
 class HostingServiceInterface:
+    """ Hosting-service interface base-class. """
     name = ""
 
     def __init__(self,

--- a/hubgrep/lib/hosting_service_interfaces/gitea.py
+++ b/hubgrep/lib/hosting_service_interfaces/gitea.py
@@ -1,3 +1,7 @@
+"""
+Hosting-service interface and result-class for Gitea.
+"""
+
 import logging
 from typing import List, Union
 from iso8601 import iso8601
@@ -17,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class GiteaSearchResult(SearchResult):
-    """
+    """ Gitea search result - example response from Gitea API:
     {
       "allow_merge_commits": true,
       "allow_rebase": true,
@@ -121,6 +125,7 @@ class GiteaSearchResult(SearchResult):
 
 
 class GiteaSearch(HostingServiceInterface):
+    """ Interface for searching via Gitea. """
     name = "Gitea"
 
     def __init__(

--- a/hubgrep/lib/hosting_service_interfaces/github.py
+++ b/hubgrep/lib/hosting_service_interfaces/github.py
@@ -1,3 +1,7 @@
+"""
+Hosting-service interface and result-class for Github.
+"""
+
 import logging
 
 from iso8601 import iso8601
@@ -17,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class GitHubSearchResult(SearchResult):
-    """
+    """ GitHub search result - example response from Github API:
         {
       "id": 3081286,
       "node_id": "MDEwOlJlcG9zaXRvcnkzMDgxMjg2",
@@ -89,6 +93,7 @@ class GitHubSearchResult(SearchResult):
 
 
 class GitHubSearch(HostingServiceInterface):
+    """ Interface for searching via GitHub. """
     name = "GitHub"
 
     # https://developer.github.com/v3/search/#search-repositories

--- a/hubgrep/lib/hosting_service_interfaces/gitlab.py
+++ b/hubgrep/lib/hosting_service_interfaces/gitlab.py
@@ -1,3 +1,7 @@
+"""
+Hosting-service interface and result-class for Gitlab.
+"""
+
 import logging
 from iso8601 import iso8601
 from urllib.parse import urljoin
@@ -14,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class GitLabSearchResult(SearchResult):
-    """
+    """ GitLab search result - example response from GitLab API:
     {
       "id": 6,
       "description": "Nobis sed ipsam vero quod cupiditate veritatis hic.",
@@ -69,6 +73,7 @@ class GitLabSearchResult(SearchResult):
 
 
 class GitLabSearch(HostingServiceInterface):
+    """ Interface for searching via GitLab. """
     name = "GitLab"
 
     def __init__(

--- a/hubgrep/lib/init_logging.py
+++ b/hubgrep/lib/init_logging.py
@@ -1,3 +1,5 @@
+""" Logging initialization with defaults. """
+
 from logging.config import dictConfig
 
 

--- a/hubgrep/lib/pagination.py
+++ b/hubgrep/lib/pagination.py
@@ -1,3 +1,4 @@
+""" Create pagination objects (PageLink) used in templating. """
 import math
 from typing import List
 from collections import namedtuple

--- a/hubgrep/lib/search_form.py
+++ b/hubgrep/lib/search_form.py
@@ -5,6 +5,7 @@ Note: Not the actual HTML form, which can be found in -
 'hubgrep/frontend_blueprint/templates/components/search_form/search_form.html'
 """
 import pytz
+from typing import List
 from collections import namedtuple
 from datetime import datetime
 from flask import request
@@ -16,7 +17,7 @@ utc = pytz.UTC
 
 
 class SearchForm:
-    """ All Input-fields relate to either a repository property or a hosting-service where they a found. """
+    """ Input-fields relate to either a repository property or a hosting-service where they a found. """
     search_phrase: str
     exclude_service_checkboxes: [Checkbox]
     exclude_forks: bool
@@ -28,8 +29,9 @@ class SearchForm:
     created_before_dt: datetime
     updated_after_dt: datetime
 
-    def __init__(self, search_phrase: str = None,
-                 exclude_service_checkboxes: [Checkbox] = None,
+    def __init__(self,
+                 search_phrase: str = None,
+                 exclude_service_checkboxes: List[Checkbox] = None,
                  exclude_forks: bool = False,
                  exclude_archived: bool = False,
                  created_after: str = None,
@@ -39,16 +41,16 @@ class SearchForm:
                  created_before_dt: datetime = None,
                  updated_after_dt: datetime = None):
         """
-        :param search_phrase:
-        :param exclude_service_checkboxes:
-        :param exclude_forks:
-        :param exclude_archived:
-        :param created_after:
-        :param created_before:
-        :param updated_after:
-        :param created_after_dt:
-        :param created_before_dt:
-        :param updated_after_dt:
+        :param search_phrase: free text used for searching
+        :param exclude_service_checkboxes: a list of "Checkbox" tuples
+        :param exclude_forks: bool - removes forks form results
+        :param exclude_archived: bool -removes archived repositories from results
+        :param created_after: string - results have to be created after this date
+        :param created_before: string - results have to be created before this date
+        :param updated_after: string - only include results that have been updated after this date
+        :param created_after_dt: datetime for created_after (resolved from created_after when omitted)
+        :param created_before_dt: datetime for created_before (resolved from created_before when omitted)
+        :param updated_after_dt: datetime for updated_after (resolved from updated_after when omitted)
         """
         self.search_phrase = search_phrase
         self.exclude_service_checkboxes = exclude_service_checkboxes
@@ -79,5 +81,10 @@ class SearchForm:
 
     @staticmethod
     def get_form_datetime_in_utc(date: str, date_format: str = DATE_FORMAT):
-        """ Normalize dates to UTC. """
+        """
+        Normalize dates into UTC.
+
+        :param date: string - date
+        :param date_format: string - parsing format, such as "%Y-%m-%d"
+        """
         return utc.localize(datetime.strptime(date, date_format))

--- a/hubgrep/lib/search_form.py
+++ b/hubgrep/lib/search_form.py
@@ -1,3 +1,9 @@
+"""
+Value-object for HubGreps main search form.
+
+Note: Not the actual HTML form, which is can be found in -
+'hubgrep/frontend_blueprint/templates/components/search_form/search_form.html'
+"""
 import pytz
 from collections import namedtuple
 from datetime import datetime
@@ -10,6 +16,7 @@ utc = pytz.UTC
 
 
 class SearchForm:
+    """ All Input-fields relate to either a repository property or a hosting-service where they a found. """
     search_phrase: str
     exclude_service_checkboxes: [Checkbox]
     exclude_forks: bool
@@ -31,6 +38,18 @@ class SearchForm:
                  created_after_dt: datetime = None,
                  created_before_dt: datetime = None,
                  updated_after_dt: datetime = None):
+        """
+        :param search_phrase:
+        :param exclude_service_checkboxes:
+        :param exclude_forks:
+        :param exclude_archived:
+        :param created_after:
+        :param created_before:
+        :param updated_after:
+        :param created_after_dt:
+        :param created_before_dt:
+        :param updated_after_dt:
+        """
         self.search_phrase = search_phrase
         self.exclude_service_checkboxes = exclude_service_checkboxes
         self.exclude_forks = exclude_forks
@@ -50,6 +69,7 @@ class SearchForm:
 
     @staticmethod
     def get_request_service_checkboxes() -> {}:
+        """ Create a checkbox for each hosting-service registered on the current HubGrep instance. """
         exclude_service_checkboxes = dict()
         for service in app.config["CACHED_HOSTING_SERVICES"]:
             is_checked = request.args.get("xs{}".format(service.id), False) == "on"
@@ -59,4 +79,5 @@ class SearchForm:
 
     @staticmethod
     def get_form_datetime_in_utc(date: str, date_format: str = DATE_FORMAT):
+        """ Normalize dates to UTC. """
         return utc.localize(datetime.strptime(date, date_format))

--- a/hubgrep/lib/search_form.py
+++ b/hubgrep/lib/search_form.py
@@ -1,7 +1,7 @@
 """
 Value-object for HubGreps main search form.
 
-Note: Not the actual HTML form, which is can be found in -
+Note: Not the actual HTML form, which can be found in -
 'hubgrep/frontend_blueprint/templates/components/search_form/search_form.html'
 """
 import pytz

--- a/hubgrep/models/__init__.py
+++ b/hubgrep/models/__init__.py
@@ -1,3 +1,7 @@
+"""
+HubGrep database models
+"""
+
 from flask_security.models import fsqla_v2 as fsqla
 import enum
 import re


### PR DESCRIPTION
So I started adding some basic docstrings to modules, classes and functions - mostly in lib so far.

The intent is that at the very least, each import has some form of descriptor that puts it in context. We also need to improve parameter descriptions.

A lot of the text will seem redundant, but I made them with stuff like this in mind (if you run python from your CLI):
```
from hubgrep.lib.hosting_service_interfaces.github import GitHubSearch; help(GitHubSearch)
```

So don't merge this PR just yet, just keep adding or changing until we both feel it's in a good initial state.